### PR TITLE
Upgraded LIBSVM to 0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-LIBSVM = "0.6"
+LIBSVM = "0.6.0"
 MLJModelInterface = "^0.3.6,^0.4"
 julia = "^1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,14 +4,17 @@ authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
 version = "0.1.2"
 
 [deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 LIBSVM = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
+MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 LIBSVM = "0.6.0"
 MLJModelInterface = "^0.3.6,^0.4"
-julia = "^1"
+julia = "1.3"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -9,8 +9,8 @@ MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+LIBSVM = "0.6"
 MLJModelInterface = "^0.3.6,^0.4"
-LIBSVM = "^0.4, 0.5"
 julia = "^1"
 
 [extras]


### PR DESCRIPTION
- Bumped `compat` version of `LIBSVM` to `0.6`
- Done instead of https://github.com/alan-turing-institute/MLJLIBSVMInterface.jl/pull/7 because of the issue described in https://github.com/alan-turing-institute/MLJ.jl/issues/550