### PR TITLE
Add `clean!` method to catch attempts to use pre-computed kernels

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using LinearAlgebra
 
 using MLJLIBSVMInterface
 import StableRNGs
-
+import LIBSVM
 
 ## CLASSIFIERS
 
@@ -90,3 +90,8 @@ ocpred = MLJBase.transform(oneclasssvm,
 @test isapprox((length(train) - sum(MLJBase.transform(oneclasssvm, fitresultoc, selectrows(X, train)) .== true)) / length(train), oneclasssvm.nu, atol=0.005)
 @test isapprox((length(test) - sum(ocpred .== true))  / length(test), oneclasssvm.nu, atol=0.05)
 
+## PRECOMPUTED KERNELS
+
+model = @test_logs((:warn, MLJLIBSVMInterface.WARN_PRECOMPUTED_KERNEL),
+                   SVC(kernel=LIBSVM.Kernel.Precomputed))
+@test model.kernel == LIBSVM.Kernel.RadialBasis


### PR DESCRIPTION
The current version of LIBSVM.jl in the Project.toml does not support pre-computed kernels but you can nevertheless attempt to use them, with incorrect results ensuing.

This PR changes a pre-computed kernel to radial basis functions kernel and issues an explanatory a warning.

@till-m

This is stop gap while we wait for #11.
