### PR TITLE
Allow `kernel` to be callable, fix some sloppy implementation of the MLJ interface; add docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 CategoricalArrays = "0.10"
 LIBSVM = "0.8"
-MLJModelInterface = "^0.3.6,^0.4, 1.0"
+MLJModelInterface = "1.4"
 julia = "1.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 CategoricalArrays = "0.10"
-LIBSVM = "0.8.0"
+LIBSVM = "0.8"
 MLJModelInterface = "^0.3.6,^0.4, 1.0"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJLIBSVMInterface"
 uuid = "61c7150f-6c77-4bb1-949c-13197eac2a52"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-LIBSVM = "0.6.0"
+LIBSVM = "0.8.0"
 MLJModelInterface = "^0.3.6,^0.4, 1.0"
 julia = "1.3"
 

--- a/src/MLJLIBSVMInterface.jl
+++ b/src/MLJLIBSVMInterface.jl
@@ -449,6 +449,7 @@ end
 MMI.fitted_params(::LinearSVC, fitresult) =
     (libsvm_model=fitresult[1], encoding=get_encoding(fitresult[2]))
 
+
 function MMI.fit(model::Union{SVC, NuSVC}, verbosity::Int, X, y, weights=nothing)
 
     Xmatrix = MMI.matrix(X)' # notice the transpose

--- a/src/MLJLIBSVMInterface.jl
+++ b/src/MLJLIBSVMInterface.jl
@@ -485,7 +485,6 @@ function MMI.fit(model::OneClassSVM, verbosity::Int, X)
     decision_scores = view(decision_matrix, 1, :)
     orientation = MLJLIBSVMInterface.orientation(decision_scores)
     scores = orientation*decision_scores
-    @show p
 
     fitresult = (libsvm_model, orientation)
     report = (gamma=model.gamma, scores=scores)
@@ -537,9 +536,9 @@ MMI.supports_class_weights(::Type{<:SVC}) = true
 
 MMI.human_name(::Type{<:LinearSVC}) = "linear support vector classifier"
 MMI.human_name(::Type{<:SVC}) = "C-support vector classifier"
-MMI.human_name(::Type{<:NuSVC}) = "nu-support vector classifier"
-MMI.human_name(::Type{<:NuSVR}) = "nu-support vector regressor"
-MMI.human_name(::Type{<:EpsilonSVR}) = "epsilon-support vector regressor"
+MMI.human_name(::Type{<:NuSVC}) = "ν-support vector classifier"
+MMI.human_name(::Type{<:NuSVR}) = "ν-support vector regressor"
+MMI.human_name(::Type{<:EpsilonSVR}) = "ϵ-support vector regressor"
 MMI.human_name(::Type{<:OneClassSVM}) = "$one-class support vector machine"
 
 MMI.package_name(::Type{<:SVM}) = "LIBSVM"
@@ -575,10 +574,10 @@ const DOC_ALGORITHM_LINEAR = "Reference for algorithm and core C-library: "*
 
 const DOC_KERNEL = """
 - `kernel=LIBSVM.Kernel.RadialBasis`: either an object that can be
-  called, as in `kernel(x1, x2)` (where `x1` and `x2` are vectors
-  whose length matches the number of columns of the training data `X`,
-  see examples below) or one of the following built-in kernels from
-  the LIBSVM package:
+  called, as in `kernel(x1, x2)`, or one of the built-in kernels from
+  the LIBSVM.jl package listed below.  Here `x1` and `x2` are vectors
+  whose lengths match the number of columns of the training data `X`,
+  see examples below.
 
   - `LIBSVM.Kernel.Linear`: `(x1, x2) -> x1'*x2`
 
@@ -588,7 +587,7 @@ const DOC_KERNEL = """
 
   - `LIBSVM.Kernel.Sigmoid`: `(x1, x2) - > tanh(gamma*x1'*x2 + coef0)`
 
-  where `gamma`, `coef0`, `degree` are other hyper-parameters.
+  Here `gamma`, `coef0`, `degree` are other hyper-parameters.
 
 - `gamma = 0.0`: kernel parameter (see above); if `gamma==-1.0` then
   `gamma = 1/nfeatures` is used in training, where `nfeatures` is the
@@ -832,7 +831,7 @@ julia> yhat = predict(mach, Xnew)
  "virginica"
 ```
 
-## Using a user-defined kernel
+## User-defined kernels
 
 ```
 k(x1, x2) = x1'*x2 # equivalent to `LIBSVM.Kernel.Linear`
@@ -877,7 +876,7 @@ $(MMI.doc_header(NuSVC))
 
 $DOC_ALGORITHM
 
-This model is simply a reparameterization of the [`SVC`](@ref)
+This model is simply a re-parameterization of the [`SVC`](@ref)
 classifier, where `nu` replaces `cost`, and is therefore mathematically
 equivalent to it.
 
@@ -965,7 +964,7 @@ julia> yhat = predict(mach, Xnew)
  "virginica"
 ```
 
-## Using a user-defined kernel
+## User-defined kernels
 
 ```
 k(x1, x2) = x1'*x2 # equivalent to `LIBSVM.Kernel.Linear`
@@ -977,21 +976,6 @@ julia> yhat = predict(mach, Xnew)
  "virginica"
  "virginica"
  "virginica"
-```
-
-## Incorporating class weights
-
-In either scenario above, we can do:
-
-```julia
-weights = Dict("virginica" => 1, "versicolor" => 20, "setosa" => 1)
-mach = machine(model, X, y, weights) |> fit!
-
-julia> yhat = predict(mach, Xnew)
-3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
- "versicolor"
- "versicolor"
- "versicolor"
 ```
 
 See also the classifiers [`SVC`](@ref) and [`LinearSVC`](@ref),
@@ -1011,7 +995,7 @@ $(MMI.doc_header(EpsilonSVR))
 $DOC_ALGORITHM
 
 This model is an adaptation of the classifier `SVC` to regression, but
-has an additional parameter `epsilon` (denoted `ϵ` in the cited
+has an additional parameter `epsilon` (denoted ``ϵ`` in the cited
 reference).
 
 
@@ -1094,7 +1078,7 @@ julia> yhat = predict(mach, Xnew)
  -0.2482949812264707
 ```
 
-## Using a user-defined kernel
+## User-defined kernels
 
 ```
 k(x1, x2) = x1'*x2 # equivalent to `LIBSVM.Kernel.Linear`
@@ -1124,7 +1108,7 @@ $(MMI.doc_header(NuSVR))
 
 $DOC_ALGORITHM
 
-This model is a reparameterization of `EpsilonSCV` in which the
+This model is a re-parameterization of `EpsilonSVR` in which the
 `epsilon` hyper-parameter is replaced with a new parameter `nu`
 (denoted ``ν`` in the cited reference) which attempts to control the
 number of support vectors directly.
@@ -1209,7 +1193,7 @@ julia> yhat = predict(mach, Xnew)
  -0.2076156254934889
 ```
 
-## Using a user-defined kernel
+## User-defined kernels
 
 ```
 k(x1, x2) = x1'*x2 # equivalent to `LIBSVM.Kernel.Linear`
@@ -1241,14 +1225,14 @@ $DOC_ALGORITHM
 
 This model is an outlier detection model delivering raw scores based
 on the decision function of a support vector machine. Like the
-[`NuSVC`](@ref) classifier, it uses the `nu` reparameterization of the
+[`NuSVC`](@ref) classifier, it uses the `nu` re-parameterization of the
 `cost` parameter appearing in standard support vector classification
 [`SVC`](@ref).
 
 To extract
 normalized scores ("probabilities") wrap the model using
 `ProbabilisticDetector` from
-[OutlierDection.jl](https://github.com/OutlierDetectionJL/OutlierDetection.jl). For
+[OutlierDetection.jl](https://github.com/OutlierDetectionJL/OutlierDetection.jl). For
 threshold-based classification, wrap the probabilistic model using
 MLJ's `BinaryThresholdPredictor`. Examples of wrapping appear below.
 
@@ -1285,8 +1269,13 @@ $DOC_KERNEL
 
 # Operations
 
-- `transform(mach, Xnew)`: return predictions of the target, given
-  features `Xnew` having the same scitype as `X` above.
+- `transform(mach, Xnew)`: return scores for outlierness, given
+  features `Xnew` having the same scitype as `X` above. The greater
+  the score, the more likely it is an outlier. This score is based on
+  the SVM decision function. For normalized scores, wrap `model` using
+  `ProbabilisticDetector` from OutlierDetection.jl and call `predict`
+  instead, and for threshold-based classification, wrap again using
+  `BinaryThresholdPredictor`. See the examples below.
 
 
 # Fitted parameters
@@ -1297,7 +1286,11 @@ The fields of `fitted_params(mach)` are:
 
 - `orientation`: this equals `1` if the decision function for
   `libsvm_model` is increasing with increasing outlierness, and `-1`
-  if it is decreasing instead. Correspondingly, the `libsvm_model` attaches
+  if it is decreasing instead. Correspondingly, the `libsvm_model`
+  attaches `true` to outliers in the first case, and `false` in the
+  second. (The `scores` given in the MLJ report and generated by
+  `MLJ.transform` already correct for this ambiguity, which is
+  therefore only an issue for users directly accessing `libsvm_model`.)
 
 
 # Report
@@ -1368,6 +1361,14 @@ julia> pdf.(y_prob, "outlier")
  9.572583265925801e-5
  0.0
 
+# raw scores are still available using `transform`:
+
+julia> transform(pmach, Xnew)
+2-element Vector{Float64}:
+ 9.572583265925801e-5
+ 0.0
+```
+
 
 ## Outlier classification using a probability threshold:
 
@@ -1377,40 +1378,32 @@ Continuing the previous example:
 dmodel = BinaryThresholdPredictor(pmodel, threshold=0.9)
 dmach = machine(dmodel, X) |> fit!
 
-## Using a user-defined kernel
+julia> yhat = predict(dmach, Xnew)
+2-element CategoricalArrays.CategoricalArray{String,1,UInt8}:
+ "normal"
+ "normal"
+```
 
+## User-defined kernels
+
+Continuing the first example:
 
 ```
 k(x1, x2) = x1'*x2 # equivalent to `LIBSVM.Kernel.Linear`
 model = OneClassSVM(kernel=k)
-mach = machine(model, X, y) |> fit!
+mach = machine(model, X) |> fit!
 
-julia> yhat = predict(mach, Xnew)
-3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
- "virginica"
- "virginica"
- "virginica"
+julia> yhat = transform(mach, Xnew)
+2-element Vector{Float64}:
+ -0.4825363352732942
+ -0.4848772169720227
 ```
 
-## Incorporating class weights
-
-In either scenario above, we can do:
-
-```julia
-weights = Dict("virginica" => 1, "versicolor" => 20, "setosa" => 1)
-mach = machine(model, X, y, weights) |> fit!
-
-julia> yhat = predict(mach, Xnew)
-3-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
- "versicolor"
- "versicolor"
- "versicolor"
-```
-
-See also the classifiers [`SVC`](@ref) and [`LinearSVC`](@ref),
-[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the
+See also [LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the
 [documentation](https://github.com/cjlin1/libsvm/blob/master/README)
-for the original C implementation.
+for the original C implementation. For an alternative source of
+outlier detection models with an MLJ interface, see
+[OutlierDetection.jl](https://outlierdetectionjl.github.io/OutlierDetection.jl/dev/).
 
 """
 OneClassSVM

--- a/src/MLJLIBSVMInterface.jl
+++ b/src/MLJLIBSVMInterface.jl
@@ -564,13 +564,13 @@ const DOC_REFERENCE = "C.-C. Chang and C.-J. Lin (2011): \"LIBSVM: a library for
 
 const DOC_ALGORITHM = "Reference for algorithm and core C-library: $DOC_REFERENCE. "
 
-const DOC_REFERENCE_LINEAR = "Rong-En Fan et al (2008): \"LIBLINEAR: A Library for "*
+const DOC_REFERENCE2 = "Rong-En Fan et al (2008): \"LIBLINEAR: A Library for "*
     "Large Linear Classification.\" *Journal of Machine Learning Research* 9 1871-1874. "*
     "Available at [https://www.csie.ntu.edu.tw/~cjlin/papers/liblinear.pdf]"*
     "(https://www.csie.ntu.edu.tw/~cjlin/papers/liblinear.pdf)"
 
 const DOC_ALGORITHM_LINEAR = "Reference for algorithm and core C-library: "*
-    "$DOC_REFERENCE_LINEAR. "
+    "$DOC_REFERENCE2. "
 
 const DOC_KERNEL = """
 - `kernel=LIBSVM.Kernel.RadialBasis`: either an object that can be
@@ -583,7 +583,7 @@ const DOC_KERNEL = """
 
   - `LIBSVM.Kernel.Polynomial`: `(x1, x2) -> gamma*x1'*x2 + coef0)^degree`
 
-  - `LIBSVM.Kernel.RadialBasis`: `(x1, x2) -> (exp(-gamma*norm(x1, x2)^2)`
+  - `LIBSVM.Kernel.RadialBasis`: `(x1, x2) -> (exp(-gamma*norm(x1 - x2)^2))`
 
   - `LIBSVM.Kernel.Sigmoid`: `(x1, x2) - > tanh(gamma*x1'*x2 + coef0)`
 
@@ -876,9 +876,10 @@ $(MMI.doc_header(NuSVC))
 
 $DOC_ALGORITHM
 
-This model is simply a re-parameterization of the [`SVC`](@ref)
-classifier, where `nu` replaces `cost`, and is therefore mathematically
-equivalent to it.
+This model is a re-parameterization of the [`SVC`](@ref) classifier,
+where `nu` replaces `cost`, and is therefore mathematically equivalent
+to it. The parameter `nu` allows more direct control over the number
+of support vectors (see under "Hyper-parameters below").
 
 
 # Training data
@@ -906,7 +907,10 @@ $DOC_KERNEL
 
 - `nu=0.5` (range (0, 1]): An upper bound on the fraction of margin
   errors and a lower bound of the fraction of support vectors. Denoted
-  `ν` in the cited paper.
+  `ν` in the cited paper. Changing `nu` changes the thickness of the
+  margin (a neighborhood of the decision surface) and a margin error
+  is said to have occurred if a training observation lies on the wrong
+  side of the surface or within the margin.
 
 - `cachesize=200.0` cache memory size in MB
 
@@ -1139,9 +1143,12 @@ Train the machine using `fit!(mach, rows=...)`.
 - `cost=1.0` (range (0, `Inf`)): the parameter denoted ``C`` in the
   cited reference; for greater regularization, decrease `cost`
 
-- `nu=0.5` (range (0, 1]): An upper bound on the fraction of margin
-  errors and a lower bound of the fraction of support vectors. Denoted
-  ``ν`` in the cited paper.
+- `nu=0.5` (range (0, 1]): An upper bound on the fraction of training
+  errors and a lower bound of the fraction of support vectors.
+  Denoted ``ν`` in the cited paper. Changing `nu` changes the
+  thickness of some neighborhood of the graph of the prediction
+  function (called a "tube" or "slab") and a training error is said to
+  occur when a data point `(x, y)` lies outside of that neighborhood.
 
 - `cachesize=200.0` cache memory size in MB
 
@@ -1258,7 +1265,10 @@ $DOC_KERNEL
 
 - `nu=0.5` (range (0, 1]): An upper bound on the fraction of margin
   errors and a lower bound of the fraction of support vectors. Denoted
-  `ν` in the cited paper.
+  `ν` in the cited paper. Changing `nu` changes the thickness of the
+  margin (a neighborhood of the decision surface) and a margin error
+  is said to have occurred if a training observation lies on the wrong
+  side of the surface or within the margin.
 
 - `cachesize=200.0` cache memory size in MB
 

--- a/src/MLJLIBSVMInterface.jl
+++ b/src/MLJLIBSVMInterface.jl
@@ -575,15 +575,14 @@ const DOC_ALGORITHM_LINEAR = "Reference for algorithm and core C-library: "*
 const DOC_SERIALIZABILITY = "Serialization of "*
     "models with user-defined kernels comes with some restrictions. "*
     "See [LIVSVM.jl issue"*
-    "91](https://github.com/JuliaML/LIBSVM.jl/issues/91]"*
-    "(https://github.com/JuliaML/LIBSVM.jl/issues/91)"
+    "91](https://github.com/JuliaML/LIBSVM.jl/issues/91)"
 
 const DOC_KERNEL = """
 - `kernel=LIBSVM.Kernel.RadialBasis`: either an object that can be
   called, as in `kernel(x1, x2)`, or one of the built-in kernels from
   the LIBSVM.jl package listed below.  Here `x1` and `x2` are vectors
-  whose lengths match the number of columns of the training data `X`,
-  see examples below.
+  whose lengths match the number of columns of the training data `X` (see
+  "Examples" below).
 
   - `LIBSVM.Kernel.Linear`: `(x1, x2) -> x1'*x2`
 
@@ -729,10 +728,10 @@ julia> yhat = predict(mach, Xnew)
 ```
 
 
-See also the [`SVC`](@ref) and [`NuSVC`] classifiers, and
-[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the
-[documentation](https://github.com/cjlin1/liblinear/blob/master/README)
-for the original C implementation.
+See also the [`SVC`](@ref) and [`NuSVC`](@ref) classifiers, and
+[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the original C
+implementation
+[documentation](https://github.com/cjlin1/liblinear/blob/master/README).
 
 """
 LinearSVC
@@ -819,7 +818,7 @@ The fields of `report(mach)` are:
 using MLJ
 import LIBSVM
 
-SVC = @load SVC pkg=LIBSVM               # model type
+SVC = @load SVC pkg=LIBSVM                   # model type
 model = SVC(kernel=LIBSVM.Kernel.Polynomial) # instance
 
 X, y = @load_iris # table, vector
@@ -867,9 +866,9 @@ julia> yhat = predict(mach, Xnew)
 ```
 
 See also the classifiers [`NuSVC`](@ref) and [`LinearSVC`](@ref), and
-[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the
-[documentation](https://github.com/cjlin1/libsvm/blob/master/README)
-for the original C implementation.
+[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the original C
+implementation
+[documentation](https://github.com/cjlin1/libsvm/blob/master/README).
 
 """
 SVC
@@ -883,9 +882,9 @@ $(MMI.doc_header(NuSVC))
 $DOC_ALGORITHM
 
 This model is a re-parameterization of the [`SVC`](@ref) classifier,
-where `nu` replaces `cost`, and is therefore mathematically equivalent
-to it. The parameter `nu` allows more direct control over the number
-of support vectors (see under "Hyper-parameters below").
+where `nu` replaces `cost`, and is mathematically equivalent to
+it. The parameter `nu` allows more direct control over the number of
+support vectors (see under "Hyper-parameters").
 
 
 # Training data
@@ -956,7 +955,7 @@ The fields of `report(mach)` are:
 using MLJ
 import LIBSVM
 
-NuSVC = @load NuSVC pkg=LIBSVM               # model type
+NuSVC = @load NuSVC pkg=LIBSVM                 # model type
 model = NuSVC(kernel=LIBSVM.Kernel.Polynomial) # instance
 
 X, y = @load_iris # table, vector
@@ -989,9 +988,10 @@ julia> yhat = predict(mach, Xnew)
 ```
 
 See also the classifiers [`SVC`](@ref) and [`LinearSVC`](@ref),
-[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the
-[documentation](https://github.com/cjlin1/libsvm/blob/master/README)
-for the original C implementation.
+[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the original C
+implementation.
+[documentation](https://github.com/cjlin1/libsvm/blob/master/README).
+
 
 """
 NuSVC
@@ -1035,8 +1035,11 @@ $DOC_KERNEL
   cited reference; for greater regularization, decrease `cost`
 
 - `epsilon=0.1` (range (0, `Inf`)): the parameter denoted ``ϵ`` in the
-  cited reference; `epsilon` is the thickness of the "penalty-free"
-  neighborhood of the decision surface.
+  cited reference; `epsilon` is the thickness of the penalty-free
+  neighborhood of the graph of the prediction function ("slab"
+  or "tube"). Specifically, a data point `(x, y)` incurs no training
+  loss unless it is outside this neighborhood; the further away it is
+  from the this neighborhood, the greater the loss penalty.
 
 - `cachesize=200.0` cache memory size in MB
 
@@ -1103,9 +1106,9 @@ julia> yhat = predict(mach, Xnew)
 ```
 
 See also [`NuSVR`](@ref),
-[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the
-[documentation](https://github.com/cjlin1/libsvm/blob/master/README)
-for the original C implementation.
+[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the original C
+implementation
+[documentation](https://github.com/cjlin1/libsvm/blob/master/README).
 
 """
 EpsilonSVR
@@ -1153,8 +1156,8 @@ Train the machine using `fit!(mach, rows=...)`.
   errors and a lower bound of the fraction of support vectors.
   Denoted ``ν`` in the cited paper. Changing `nu` changes the
   thickness of some neighborhood of the graph of the prediction
-  function (called a "tube" or "slab") and a training error is said to
-  occur when a data point `(x, y)` lies outside of that neighborhood.
+  function ("tube" or "slab") and a training error is said to occur
+  when a data point `(x, y)` lies outside of that neighborhood.
 
 - `cachesize=200.0` cache memory size in MB
 
@@ -1191,7 +1194,7 @@ The fields of `report(mach)` are:
 using MLJ
 import LIBSVM
 
-NuSVR = @load NuSVR pkg=LIBSVM            # model type
+NuSVR = @load NuSVR pkg=LIBSVM                 # model type
 model = NuSVR(kernel=LIBSVM.Kernel.Polynomial) # instance
 
 X, y = make_regression(rng=123) # table, vector
@@ -1221,9 +1224,9 @@ julia> yhat = predict(mach, Xnew)
 ```
 
 See also [`EpsilonSVR`](@ref),
-[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the
-[documentation](https://github.com/cjlin1/libsvm/blob/master/README)
-for the original C implementation.
+[LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the original C
+implementation
+[documentation](https://github.com/cjlin1/libsvm/blob/master/README).
 
 """
 NuSVR
@@ -1416,9 +1419,10 @@ julia> yhat = transform(mach, Xnew)
 ```
 
 See also [LIVSVM.jl](https://github.com/JuliaML/LIBSVM.jl) and the
-[documentation](https://github.com/cjlin1/libsvm/blob/master/README)
-for the original C implementation. For an alternative source of
-outlier detection models with an MLJ interface, see
+original C implementation
+[documentation](https://github.com/cjlin1/libsvm/blob/master/README). For
+an alternative source of outlier detection models with an MLJ
+interface, see
 [OutlierDetection.jl](https://outlierdetectionjl.github.io/OutlierDetection.jl/dev/).
 
 """

--- a/src/MLJLIBSVMInterface.jl
+++ b/src/MLJLIBSVMInterface.jl
@@ -376,6 +376,11 @@ function get_svm_parameters(model::Union{SVC, NuSVC, NuSVR, EpsilonSVR, OneClass
     return params
 end
 
+function get_encoding(decoder)
+    refs = MMI.int.(decoder.classes)
+    return Dict(i => decoder(i) for i in refs)
+end
+
 function MMI.fit(model::LinearSVC, verbosity::Int, X, y)
 
     Xmatrix = MMI.matrix(X)' # notice the transpose
@@ -395,6 +400,9 @@ function MMI.fit(model::LinearSVC, verbosity::Int, X, y)
 
     return fitresult, cache, report
 end
+
+MMI.fitted_params(::LinearSVC, fitresult) =
+    (libsvm_model=fitresult[1], encoding=get_encoding(fitresult[2]))
 
 function MMI.fit(model::Union{SVC, NuSVC}, verbosity::Int, X, y)
 
@@ -418,6 +426,10 @@ function MMI.fit(model::Union{SVC, NuSVC}, verbosity::Int, X, y)
     return fitresult, cache, report
 end
 
+MMI.fitted_params(::Union{SVC, NuSVC}, fitresult) =
+    (libsvm_model=fitresult[1], encoding=get_encoding(fitresult[2]))
+
+
 function MMI.fit(model::Union{NuSVR, EpsilonSVR}, verbosity::Int, X, y)
 
     Xmatrix = MMI.matrix(X)' # notice the transpose
@@ -436,6 +448,10 @@ function MMI.fit(model::Union{NuSVR, EpsilonSVR}, verbosity::Int, X, y)
 
     return fitresult, cache, report
 end
+
+MMI.fitted_params(::Union{NuSVR, EpsilonSVR}, fitresult) =
+    (libsvm_model=fitresult,)
+
 
 function MMI.fit(model::OneClassSVM, verbosity::Int, X)
 
@@ -456,6 +472,11 @@ function MMI.fit(model::OneClassSVM, verbosity::Int, X)
     return fitresult, cache, report
 end
 
+MMI.fitted_params(::OneClassSVM, fitresult) =
+    (libsvm_model=fitresult,)
+
+
+# # PREDICT METHODS
 
 function MMI.predict(model::LinearSVC, fitresult, Xnew)
     result, decode = fitresult

--- a/src/MLJLIBSVMInterface.jl
+++ b/src/MLJLIBSVMInterface.jl
@@ -18,18 +18,10 @@ const PKG = "MLJLIBSVMInterface"
 
 # # MODEL TYPES
 
-"""
-    LinearSVC(; kwargs...)
-
-Linear support vector machine classifier using LIBLINEAR: https://www.csie.ntu.edu.tw/~cjlin/liblinear/
-
-See also SVC, NuSVC
-"""
 mutable struct LinearSVC <: MMI.Deterministic
     solver::LIBSVM.Linearsolver.LINEARSOLVER
     tolerance::Float64
     cost::Float64
-    p::Float64
     bias::Float64
 end
 
@@ -37,14 +29,12 @@ function LinearSVC(
     ;solver::LIBSVM.Linearsolver.LINEARSOLVER = LIBSVM.Linearsolver.L2R_L2LOSS_SVC_DUAL
     ,tolerance::Float64 = Inf
     ,cost::Float64 = 1.0
-    ,p::Float64 = 0.1
     ,bias::Float64= -1.0)
 
     model = LinearSVC(
         solver
         ,tolerance
         ,cost
-        ,p
         ,bias
     )
 
@@ -563,6 +553,13 @@ MMI.load_path(::Type{<:OneClassSVM}) = "$PKG.OneClassSVM"
 MMI.supports_class_weights(::Type{<:LinearSVC}) = true
 MMI.supports_class_weights(::Type{<:SVC}) = true
 
+MMI.human_name(::Type{<:LinearSVC}) = "linear support vector classifier"
+MMI.human_name(::Type{<:SVC}) = "C-support vector classifier"
+MMI.human_name(::Type{<:NuSVC}) = "nu-support vector classifier"
+MMI.human_name(::Type{<:NuSVR}) = "nu-support vector regressor"
+MMI.human_name(::Type{<:EpsilonSVR}) = "epsilon-support vector regressor"
+MMI.human_name(::Type{<:OneClassSVM}) = "$one-class support vector machine"
+
 MMI.package_name(::Type{<:SVM}) = "LIBSVM"
 MMI.package_uuid(::Type{<:SVM}) = "b1bec4e5-fd48-53fe-b0cb-9723c09d164b"
 MMI.is_pure_julia(::Type{<:SVM}) = false
@@ -574,5 +571,7 @@ MMI.target_scitype(::Type{<:Union{NuSVR, EpsilonSVR}}) =
     AbstractVector{Continuous}
 MMI.output_scitype(::Type{<:OneClassSVM}) =
     AbstractVector{<:Finite{2}} # Bool (true means inlier)
+
+
 
 end # module

--- a/src/MLJLIBSVMInterface.jl
+++ b/src/MLJLIBSVMInterface.jl
@@ -572,6 +572,12 @@ const DOC_REFERENCE2 = "Rong-En Fan et al (2008): \"LIBLINEAR: A Library for "*
 const DOC_ALGORITHM_LINEAR = "Reference for algorithm and core C-library: "*
     "$DOC_REFERENCE2. "
 
+const DOC_SERIALIZABILITY = "Serialization of "*
+    "models with user-defined kernels comes with some restrictions. "*
+    "See [LIVSVM.jl issue"*
+    "91](https://github.com/JuliaML/LIBSVM.jl/issues/91]"*
+    "(https://github.com/JuliaML/LIBSVM.jl/issues/91)"
+
 const DOC_KERNEL = """
 - `kernel=LIBSVM.Kernel.RadialBasis`: either an object that can be
   called, as in `kernel(x1, x2)`, or one of the built-in kernels from
@@ -587,7 +593,7 @@ const DOC_KERNEL = """
 
   - `LIBSVM.Kernel.Sigmoid`: `(x1, x2) - > tanh(gamma*x1'*x2 + coef0)`
 
-  Here `gamma`, `coef0`, `degree` are other hyper-parameters.
+  Here `gamma`, `coef0`, `degree` are other hyper-parameters. $DOC_SERIALIZABILITY
 
 - `gamma = 0.0`: kernel parameter (see above); if `gamma==-1.0` then
   `gamma = 1/nfeatures` is used in training, where `nfeatures` is the

--- a/src/MLJLIBSVMInterface.jl
+++ b/src/MLJLIBSVMInterface.jl
@@ -68,7 +68,7 @@ used in fitting
 See also LinearSVC, NuSVC
 """
 mutable struct SVC <: MMI.Deterministic
-    kernel::LIBSVM.Kernel.KERNEL
+    kernel
     gamma::Float64
     weights::Union{Dict, Nothing}
     cost::Float64
@@ -81,7 +81,7 @@ mutable struct SVC <: MMI.Deterministic
 end
 
 function SVC(
-    ;kernel::LIBSVM.Kernel.KERNEL = LIBSVM.Kernel.RadialBasis
+    ;kernel = LIBSVM.Kernel.RadialBasis
     ,gamma::Float64 = 0.0
     ,weights::Union{Dict, Nothing} = nothing
     ,cost::Float64 = 1.0
@@ -124,7 +124,7 @@ used in fitting
 See also LinearSVC, SVC
 """
 mutable struct NuSVC <: MMI.Deterministic
-    kernel::LIBSVM.Kernel.KERNEL
+    kernel
     gamma::Float64
     weights::Union{Dict, Nothing}
     nu::Float64
@@ -137,7 +137,7 @@ mutable struct NuSVC <: MMI.Deterministic
 end
 
 function NuSVC(
-    ;kernel::LIBSVM.Kernel.KERNEL = LIBSVM.Kernel.RadialBasis
+    ;kernel = LIBSVM.Kernel.RadialBasis
     ,gamma::Float64 = 0.0
     ,weights::Union{Dict, Nothing} = nothing
     ,nu::Float64 = 0.5
@@ -168,7 +168,7 @@ function NuSVC(
 end
 
 mutable struct OneClassSVM <: MMI.Unsupervised
-    kernel::LIBSVM.Kernel.KERNEL
+    kernel
     gamma::Float64
     nu::Float64
     cost::Float64
@@ -180,7 +180,7 @@ mutable struct OneClassSVM <: MMI.Unsupervised
 end
 
 function OneClassSVM(
-    ;kernel::LIBSVM.Kernel.KERNEL = LIBSVM.Kernel.RadialBasis
+    ;kernel = LIBSVM.Kernel.RadialBasis
     ,gamma::Float64 = 0.0
     ,nu::Float64 = 0.1
     ,cost::Float64 = 1.0
@@ -221,7 +221,7 @@ used in fitting
 See also EpsilonSVR
 """
 mutable struct NuSVR <: MMI.Deterministic
-    kernel::LIBSVM.Kernel.KERNEL
+    kernel
     gamma::Float64
     nu::Float64
     cost::Float64
@@ -233,7 +233,7 @@ mutable struct NuSVR <: MMI.Deterministic
 end
 
 function NuSVR(
-    ;kernel::LIBSVM.Kernel.KERNEL = LIBSVM.Kernel.RadialBasis
+    ;kernel = LIBSVM.Kernel.RadialBasis
     ,gamma::Float64 = 0.0
     ,nu::Float64 = 0.5
     ,cost::Float64 = 1.0
@@ -274,7 +274,7 @@ used in fitting
 See also NuSVR
 """
 mutable struct EpsilonSVR <: MMI.Deterministic
-    kernel::LIBSVM.Kernel.KERNEL
+    kernel
     gamma::Float64
     epsilon::Float64
     cost::Float64
@@ -286,7 +286,7 @@ mutable struct EpsilonSVR <: MMI.Deterministic
 end
 
 function EpsilonSVR(
-    ;kernel::LIBSVM.Kernel.KERNEL = LIBSVM.Kernel.RadialBasis
+    ;kernel = LIBSVM.Kernel.RadialBasis
     ,gamma::Float64 = 0.0
     ,epsilon::Float64 = 0.1
     ,cost::Float64 = 1.0
@@ -320,17 +320,17 @@ const SVM = Union{LinearSVC, SVC, NuSVC, NuSVR, EpsilonSVR, OneClassSVM}
 
 # # CLEAN METHOD
 
-const WARN_PRECOMPUTED_KERNEL =
+const ERR_PRECOMPUTED_KERNEL = ArgumentError(
     "Pre-computed kernels are not supported by installed version of "*
-    "MLJLIBSVMInterface.jl. Using `LIBSVM.Kernel.RadialBasis` instead. "
+    "MLJLIBSVMInterface.jl. Alternatively, specify `kernel=k` for some "*
+    "function or callable `k(v1::AbstractVector, v2::AbstractVector)`. "
+)
 
 function MMI.clean!(model::SVM)
     message = ""
-    if !(model isa LinearSVC) &&
-        model.kernel == LIBSVM.Kernel.Precomputed
-        message *= WARN_PRECOMPUTED_KERNEL
-        model.kernel = LIBSVM.Kernel.RadialBasis
-    end
+    !(model isa LinearSVC) &&
+        model.kernel == LIBSVM.Kernel.Precomputed &&
+        throw(ERR_PRECOMPUTED_KERNEL)
     return message
 end
 

--- a/src/MLJLIBSVMInterface.jl
+++ b/src/MLJLIBSVMInterface.jl
@@ -481,7 +481,7 @@ function MMI.fit(model::OneClassSVM, verbosity::Int, X)
                                    )
 
     # get orientation and training scores:
-    p, decision_matrix = LIBSVM.svmpredict(libsvm_model, Xmatrix)
+    _, decision_matrix = LIBSVM.svmpredict(libsvm_model, Xmatrix)
     decision_scores = view(decision_matrix, 1, :)
     orientation = MLJLIBSVMInterface.orientation(decision_scores)
     scores = orientation*decision_scores

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,15 @@ lcpred = MLJBase.predict(linear_classifier, fitresultCL, selectrows(X, test));
 @test Set(classes(nucpred[1])) == Set(classes(y[1]))
 @test Set(classes(lcpred[1])) == Set(classes(y[1]))
 
+fpC = MLJBase.fitted_params(plain_classifier, fitresultC)
+fpCnu = MLJBase.fitted_params(nu_classifier, fitresultCnu)
+fpCL = MLJBase.fitted_params(linear_classifier, fitresultCL)
+
+for fp in [fpC, fpCnu, fpCL]
+    @test keys(fp) == (:libsvm_model, :encoding)
+    @test fp.encoding[int(MLJBase.classes(y)[1])] == classes(y)[1]
+end
+
 rng = StableRNGs.StableRNG(123)
 
 # test with linear data:
@@ -68,6 +77,13 @@ fitresultR, cacheR, reportR = MLJBase.fit(plain_regressor, 1,
 fitresultRnu, cacheRnu, reportRnu = MLJBase.fit(nu_regressor, 1,
                                                 selectrows(X, train), y[train]);
 
+fpR = MLJBase.fitted_params(plain_regressor, fitresultR)
+fpRnu = MLJBase.fitted_params(nu_regressor, fitresultRnu)
+
+for fp in [fpR, fpRnu]
+    @test fp.libsvm_model isa LIBSVM.SVM
+end
+
 rpred = MLJBase.predict(plain_regressor, fitresultR, selectrows(X, test));
 nurpred = MLJBase.predict(nu_regressor, fitresultRnu, selectrows(X, test));
 
@@ -80,7 +96,11 @@ nurpred = MLJBase.predict(nu_regressor, fitresultRnu, selectrows(X, test));
 oneclasssvm = OneClassSVM()
 
 fitresultoc, cacheoc, reportoc = MLJBase.fit(oneclasssvm, 1,
-                                          selectrows(X, train));
+                                             selectrows(X, train));
+
+fp = MLJBase.fitted_params(oneclasssvm, fitresultoc)
+@test fp.libsvm_model isa LIBSVM.SVM
+
 # output is CategoricalArray{Bool}
 ocpred = MLJBase.transform(oneclasssvm,
                            fitresultoc,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,9 +164,8 @@ yhat₂ = MLJBase.predict(model₂, fitresult₂, X);
 
 @test accuracy(yhat, y) > 0.75
 
-model = @test_logs((:warn, MLJLIBSVMInterface.WARN_PRECOMPUTED_KERNEL),
+model = @test_throws(MLJLIBSVMInterface.ERR_PRECOMPUTED_KERNEL,
                    SVC(kernel=LIBSVM.Kernel.Precomputed))
-@test model.kernel == LIBSVM.Kernel.RadialBasis
 
 
 ## WEIGHTS
@@ -188,24 +187,24 @@ for model in [SVC(), LinearSVC()]
 
     # without weights:
     Θ, _, _ = MLJBase.fit(model, 0, Xtrain, ytrain)
-    yhat = predict(model, Θ, X);
-    @test levels(yhat) == levels(y) # the `2` class persists as a level
+    ŷ = predict(model, Θ, X);
+    @test levels(ŷ) == levels(y) # the `2` class persists as a level
 
     # with uniform weights:
     Θ_uniform, _, _ = MLJBase.fit(model, 0, Xtrain, ytrain, weights_uniform)
-    yhat_uniform = predict(model, Θ_uniform, X);
-    @test levels(yhat_uniform) == levels(y)
+    ŷ_uniform = predict(model, Θ_uniform, X);
+    @test levels(ŷ_uniform) == levels(y)
 
     # with weights favouring class `3`:
     Θ_favouring_3, _, _ = MLJBase.fit(model, 0, Xtrain, ytrain, weights_favouring_3)
-    yhat_favouring_3 = predict(model, Θ_favouring_3, X);
-    @test levels(yhat_favouring_3) == levels(y)
+    ŷ_favouring_3 = predict(model, Θ_favouring_3, X);
+    @test levels(ŷ_favouring_3) == levels(y)
 
     # comparisons:
     if !(model isa LinearSVC) # linear solver is not deterministic
-        @test yhat_uniform == yhat
+        @test ŷ_uniform == ŷ
     end
-    d = sum(yhat_favouring_3 .== 3) - sum(yhat .== 3)
+    d = sum(ŷ_favouring_3 .== 3) - sum(ŷ .== 3)
     if d <= 0
         @show model
         @show d

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,14 @@ import LIBSVM
                  MLJLIBSVMInterface.encode(Dict('d'=> 1.0), v))
 end
 
+@test "orientation of scores" begin
+    scores = [1, 1, 1, 1, 0]
+    @test MLJLIBSVMInterface.orientation(scores) == -1
+    @test MLJLIBSVMInterface.orientation(-scores) == 1
+    @test MLJLIBSVMInterface.orientation(scores .+ 100) == -1
+    @test MLJLIBSVMInterface.orientation(-scores .+ 100) == 1
+end
+
 
 ## CLASSIFIERS
 


### PR DESCRIPTION
In this PR we:

- update the compatibility requirement of LIBSVM.jl to the latest version

- (**enhancement**) Allow the `kernel` hyper-parameter to be a function or other callable 

- (**breaking**) Overload `fitted_params` of all models so as to be more user-friendly 

- (**breaking**) Remove a number of superfluous hyper-parameters (hyper-parameters whose values are ignored internally):
  - `p` from `LinearSVC` (alias for `ϵ` in the cited paper) which is only defined for regression models
  - `cost` from `NuSVC` (alias for `C` in cited paper) which is redundant as `nu` is a re-parameterization of it
  - `cost` from `OneClassSVM` (again, `nu` is used instead)

- (**breaking**) Re-implement `OneClassSVM` as a `UnsupervisedDetector` satisfying [MLJ's API](https://alan-turing-institute.github.io/MLJ.jl/dev/adding_models_for_general_use/#Outlier-detection-models) for such models. In particular, `transform(mach, Xnew)` now returns raw outlier scores. To extract normalised probabilities or for threshold outlier classification, refer to the new document string.

- (**breaking**) Re-implement `SVC` and `LinearSVC` so that optional class weight dictionaries are specified along with the training data, and fix bugs in how these were interpreted internally. Remove weight support for `NuSVC` as `LIBSVM.jl` does not appear to support it.

- (**enhancement**) Add MLJ-compliant document strings to all models, with detailed examples

My apologies for combining so much in a single PR. The original intention was just to update document strings. The issues were revealed only progressively as I worked through these.